### PR TITLE
Add a destriper to the library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*~
 *.jl.*.cov
 *.jl.cov
 *.jl.mem

--- a/Project.toml
+++ b/Project.toml
@@ -7,8 +7,12 @@ version = "0.1.0"
 Healpix = "9f4e344d-96bc-545a-84a3-ae6b9e1b672b"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
+MPI = "da04e1cc-30fd-572f-bb4f-1f8673147195"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+RunLengthArrays = "11ec6118-8d4c-11e9-02bb-6986bd51d19a"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -13,9 +13,8 @@ makedocs(modules = [CMBMissionSim],
         "Introduction" => "index.md",
         "Pointing generation" => "genpointings.md"
     ],
-    repo="https://github.com/ziotom78/CMBMissionSim.jl/blob/{commit}{path}#L{line}",
-    authors="Maurizio Tomasi",
-    assets=String[])
+    repo = "https://github.com/ziotom78/CMBMissionSim.jl/blob/{commit}{path}#L{line}",
+    authors = "Maurizio Tomasi")
 
 deploydocs(repo = "github.com/lspestrip/CMBMissionSim.jl.git",
 )

--- a/src/CMBMissionSim.jl
+++ b/src/CMBMissionSim.jl
@@ -4,5 +4,6 @@ include("quaternions.jl")
 include("genpointings.jl")
 include("dipole.jl")
 include("beams.jl")
+include("mapmaking.jl")
 
 end # module

--- a/src/covmatrix.jl
+++ b/src/covmatrix.jl
@@ -1,0 +1,9 @@
+function noise_model(freq_hz, fknee_hz, rms, alpha)
+    rms * (1 + fknee_hz / freq_hz)^alpha
+end
+
+function baseline_spectrum(freq_hz, baseline_period_s)
+    while false
+        
+    end
+end

--- a/src/mapmaking.jl
+++ b/src/mapmaking.jl
@@ -1,0 +1,1010 @@
+# -*- encoding: utf-8 -*-
+
+export PolarizedMap, NobsMatrixElement, Observation, DestripingData, CleanedTOD
+export update_nobs!, update_nobs_matrix!, observation, compute_nobs_matrix!
+export update_binned_map!, reset_maps!, compute_z_and_subgroup!, compute_z_and_group!
+export compute_residuals!, array_dot, calc_stopping_factor, apply_offset_to_baselines!
+export calculate_cleaned_map!, destripe!
+
+import LinearAlgebra: I, Symmetric, cond, diagm, dot
+import RunLengthArrays: RunLengthArray, runs, values
+import Healpix
+import Logging: @debug, @info, @warn
+import Logging: ConsoleLogger, global_logger, Info, Debug
+import Statistics: mean
+
+################################################################################
+
+# This implementation of the destriping algorithm is based on the
+# paper «Destriping CMB temperature and polarization maps» by
+# Kurki-Suonio et al. 2009, A&A 506, 1511–1539 (2009),
+# https://dx.doi.org/10.1051/0004-6361/200912361
+#
+# It is important to have that paper at hand while reading this code,
+# as many functions and variable defined here use the same letters and
+# symbols of that paper. We refer to it in code comments and
+# docstrings as "KurkiSuonio2009".
+
+################################################################################
+
+@doc raw"""
+    mutable struct PolarizedMap{T, O <: Healpix.Order}
+
+A polarized I/Q/U map. It contains three Healpix maps with the same NSIDE:
+
+- `i`
+- `q`
+- `u`
+
+You can create an instance of this type using the function
+[`PolarizedMap{T,O}`](@ref).
+
+"""
+mutable struct PolarizedMap{T, O <: Healpix.Order}
+    i::Healpix.Map{T,O}
+    q::Healpix.Map{T,O}
+    u::Healpix.Map{T,O}
+
+    PolarizedMap{T, O}(
+        i::Healpix.Map{T, O},
+        q::Healpix.Map{T, O},
+        u::Healpix.Map{T, O},
+    ) where {T, O <: Healpix.Order} = new(i, q, u)
+end
+
+function PolarizedMap{T, O}(
+    i::AbstractArray{T, 1},
+    q::AbstractArray{T, 1},
+    u::AbstractArray{T, 1},
+) where {T, O <: Healpix.Order}
+
+    @assert length(i) == length(q)
+    @assert length(i) == length(u)
+    
+    PolarizedMap{T, O}(
+        Healpix.Map{T, O}(i),
+        Healpix.Map{T, O}(q),
+        Healpix.Map{T, O}(u),
+    )
+end
+
+################################################################################
+# Matrix containing the number of observations and the condition
+# number per pixel
+
+@doc raw"""
+    mutable struct NobsMatrixElement
+
+This structure encodes the condition matrix for a pixel in the map. It
+is essentially matrix M_p in Eq. (10) of KurkiSuonio2009, but with
+steroids, as it implements the following fields:
+
+- `m`: the 3×3 matrix in Eq. (10)
+- `invm`: the 3×3 inverse of `m`
+- `invcond`: the inverse of the condition number *rcond* for `m`; this
+  field is useful to check whether the samples in a TOD and the attack
+  angles are sufficient to constrain a unique solution for I, Q, and U
+  for that pixel.
+- `neglected`: a Boolean flag telling whether the pixel was skipped or
+  not during map-making (this usually happens if `invcond` is too
+  small)
+
+A typical use case is an array of `NobsMatrixElement` objects in an
+array that get updated via [`update_nobs_matrix!`](@ref), like in the
+following example:
+
+```julia
+NPIX = 10   # Number of pixels in the map
+nobs_matrix = [NobsMatrixElement() for i in 1:NPIX]
+
+# The variables psi_angle, sigma_squared, pixidx, and flagged
+# must have been defined somewhere else; they contain the TOD
+update_nobs_matrix!(nobs_matrix, psi_angle, sigma_squared, pixidx, flagged)
+```
+
+"""
+mutable struct NobsMatrixElement
+    # We do not define "m" as symmetric, as we want to update its
+    # fields one by one; however, we only consider the upper part
+    m::Array{Float64, 2}
+    invm::Symmetric{Float64, Array{Float64, 2}}
+    invcond::Float64
+
+    # If "true", do not consider this pixel in the solution, as it was
+    # not covered enough by the scanning strategy
+    neglected::Bool
+
+    NobsMatrixElement() = new(
+        Symmetric(zeros(Float64, 3, 3)),
+        Symmetric(zeros(Float64, 3, 3)),
+        0.0,
+        true,
+    )
+end
+
+@doc raw"""
+    update_nobs!(nobs::NobsMatrixElement; threshold = 1e-7)
+
+This function makes sure that all the elements in `nobs` are
+synchronized. It should be called whenever the field `nobs.m` (matrix
+M_p in Eq. 10 of KurkiSuonio2009) has changed.
+
+"""
+function update_nobs!(nobs::NobsMatrixElement; threshold = 1e-7)
+    c = cond(nobs.m)
+
+    if isfinite(c)
+        nobs.invm = inv(Symmetric(nobs.m))
+        nobs.invcond = 1 / c
+        nobs.neglected = nobs.invcond < threshold
+    else
+        nobs.invcond = 0.0
+        nobs.neglected = true
+    end
+end
+
+@doc raw"""
+    update_nobs_matrix!(nobs_matrix::Array{NobsMatrixElement, 1}, psi_angle, sigma_squared, pixidx, flagged)
+
+Apply Eq. (10) of KurkiSuonio2009 iteratively on the samples of a TOD
+to update matrices M_p in `nobs_matrix`. The meaning of the parameters
+is the following:
+
+- `nobs_matrix` is the structure that gets updated by this function
+- `psi_angle` is an array of `N` elements, containing the polarization
+  angles (in radians)
+- `sigma_squared` is an array of `N` elements, each containing the
+  value of σ^2 for the samples in the TOD
+- `pixidx` is an array of `N` elements, containing the pixel index
+  observed by the TOD
+- `flagged` is a Boolean array of `N` elements; `true` means that the
+  sample in the TOD should not be used to produce the map. This can be
+  used to produce jackknives and to neglect moving objects in the TOD
+
+"""
+function update_nobs_matrix!(
+    nobs_matrix::Array{NobsMatrixElement, 1},
+    psi_angle,
+    sigma_squared,
+    pixidx,
+    flagged,
+)
+
+    @assert length(psi_angle) == length(sigma_squared)
+    @assert length(psi_angle) == length(pixidx)
+    @assert length(psi_angle) == length(flagged)
+    
+    for (idx, curpix, curpsi, curflagged) in zip(
+        1:length(pixidx),
+        pixidx,
+        psi_angle,
+        flagged,
+    )
+        curflagged && continue
+        
+        constant = 1 / sigma_squared[idx]
+
+        sin_term, cos_term = sincos(2 * curpsi)
+        nobs_matrix[curpix].m[1, 1] += constant
+        nobs_matrix[curpix].m[1, 2] += cos_term * constant
+        nobs_matrix[curpix].m[1, 3] += sin_term * constant
+        
+        nobs_matrix[curpix].m[2, 2] += cos_term^2 * constant
+        nobs_matrix[curpix].m[2, 3] += cos_term * sin_term * constant
+        
+        nobs_matrix[curpix].m[3, 3] += sin_term^2 * constant
+    end
+end
+
+################################################################################
+# Observations
+
+@doc raw"""
+    mutable struct Observation
+
+An *observation* is a sequence of time-ordered data (TOD) that has
+been acquired by some detector. It implements the following fields:
+
+- `time`: an array of `N` elements, representing the time of the
+  sample. Being defined as an `AbstractArray`, a range (e.g.,
+  `0.0:0.1:3600.0`) can be used to save memory
+- `pixidx`: an array of `N` elements, each being a pixel index in a
+  map. In no way the Healpix pixelization scheme is enforced; in fact,
+  the map must not even be spherical.
+- `psi_angle`: an array of `N` elements, each containing the
+  orientation of the polarization angle with respect to some fixed
+  reference system (e.g., the Ecliptic plane). The angles must be in
+  **radians**.
+- `tod`: an array of `N` elements, containing the actual data measured
+  by the instrument and already calibrated to some physical units
+  (e.g., K_CMB)
+- `sigma_squared`: an array of `N` elements, containing the squared
+  RMS of each sample. To save memory, you should usually use a
+  `RunLengthArray` here.
+- `flagged`: a Boolean array of `N` elements, telling whether the
+  sample should be discarded (`true`) or not (`false`) during the
+  map-making process.
+- `name`: a string representing the detector. This is used only for
+  debugging purposes.
+
+To create an observation, you can use the function
+[`observation`](@ref), which accepts keyword arguments as parameters
+and is therefore more readable.
+
+"""
+mutable struct Observation
+    time::AbstractArray{Float64, 1}
+    pixidx::Array{Int, 1}
+    psi_angle::Array{Float64, 1}
+
+    tod::Array{Float64, 1}
+    sigma_squared::AbstractArray{Float64, 1}
+    flagged::AbstractArray{Bool, 1}
+
+    name::String
+end
+
+function observation(
+    ;
+    time = Float64[],
+    pixidx = Int[],
+    psi_angle = Float64[],
+    tod = Float64[],
+    sigma_squared = Float64[],
+    flagged = Bool[],
+    name = "",
+)
+    @assert length(pixidx) > 0
+    @assert length(psi_angle) == length(pixidx)
+    @assert length(tod) == length(pixidx)
+
+    int_time = (length(time) > 0) ? time : 0:(length(tod) - 1)
+    sigma_squared = ((length(sigma_squared) > 0) ? sigma_squared :
+                     zeros(Float64, length(tod)))
+    flagged = (length(flagged) > 0) ? flagged : zeros(Bool, length(tod))
+
+    @assert length(int_time) == length(pixidx)
+    @assert length(sigma_squared) == length(pixidx)
+    @assert length(flagged) == length(pixidx)
+
+    Observation(
+        time,
+        pixidx,
+        psi_angle,
+        tod,
+        sigma_squared,
+        flagged,
+        name,
+    )
+end
+
+@doc raw"""
+    compute_nobs_matrix!(nobs_matrix::Array{NobsMatrixElement, 1}, observations::Array{Observation, 1})
+
+Initialize all the elements in `nobs_matrix` so that they are the
+matrices M_p in Eq. (10) of KurkiSuonio2009. The TOD is taken from the
+list of observations in the parameter `observations`.
+
+"""
+
+function compute_nobs_matrix!(
+    nobs_matrix::Array{NobsMatrixElement, 1},
+    observations::Array{Observation, 1},
+)
+    
+    for submatrix in nobs_matrix
+        submatrix.m .= 0.0
+    end
+
+    for idx in 1:length(observations)
+        update_nobs_matrix!(
+            nobs_matrix,
+            observations[idx].psi_angle,
+            observations[idx].sigma_squared,
+            observations[idx].pixidx,
+            observations[idx].flagged,
+        )
+    end
+
+    for idx in 1:length(nobs_matrix)
+        update_nobs!(nobs_matrix[idx])
+    end
+end
+
+################################################################################
+
+function update_binned_map!(
+    vec,
+    skymap::PolarizedMap{T, O},
+    hitmap::Healpix.Map{T, O},
+    obs::Observation;
+    comm = nothing,
+    unseen = missing,
+) where {T <: Number, O <: Healpix.Order}
+
+    # We use "zip" to iterate over those arrays that might not be
+    # plain Julia Arrays
+    for (idx, vecsamp, sigmasamp, mapidx) in zip(1:length(vec),
+                                                 vec,
+                                                 obs.sigma_squared,
+                                                 obs.pixidx)
+
+        sin_term, cos_term = sincos(2 * obs.psi_angle[idx])
+
+        skymap.i[mapidx] += vecsamp / sigmasamp
+        skymap.q[mapidx] += vecsamp * cos_term / sigmasamp
+        skymap.u[mapidx] += vecsamp * sin_term / sigmasamp
+        hitmap[mapidx] += 1 / sigmasamp
+    end
+
+    if comm != nothing
+        skymap.i .= MPI.allreduce(skymap.i, MPI.SUM, comm)
+        skymap.q .= MPI.allreduce(skymap.q, MPI.SUM, comm)
+        skymap.u .= MPI.allreduce(skymap.u, MPI.SUM, comm)
+        hitmap[:] = MPI.allreduce(hitmap, MPI.SUM, comm)
+    end
+end
+
+function update_binned_map!(
+    skymap::PolarizedMap{T, O},
+    hitmap::Healpix.Map{T, O},
+    obs::Observation;
+    comm = nothing,
+    unseen = missing,
+) where {T <: Number, O <: Healpix.Order}
+
+    update_binned_map!(
+        obs.tod,
+        skymap,
+        hitmap,
+        obs,
+        comm = comm,
+        unseen = unseen,
+    )
+end
+
+function update_binned_map!(
+    vec_list,
+    skymap::PolarizedMap{T, O},
+    hitmap::Healpix.Map{T, O},
+    obs_list::Array{Observation, 1};
+    comm = nothing,
+    unseen = missing,
+) where {T <: Number, O <: Healpix.Order}
+
+    @assert length(vec_list) == length(obs_list)
+    
+    for (cur_vec, cur_obs) in zip(vec_list, obs_list)
+        update_binned_map!(
+            cur_vec,
+            skymap,
+            hitmap,
+            cur_obs,
+            comm = comm,
+            unseen = unseen,
+        )
+    end
+end
+
+function update_binned_map!(
+    skymap::PolarizedMap{T, O},
+    hitmap::Healpix.Map{T, O},
+    obs_list::Array{Observation, 1};
+    comm = nothing,
+    unseen = missing,
+) where {T <: Number, O <: Healpix.Order}
+
+    for cur_obs in obs_list
+        update_binned_map!(
+            skymap,
+            hitmap,
+            cur_obs,
+            comm = comm,
+            unseen = unseen,
+        )
+    end
+end
+
+
+@doc raw"""
+    update_binned_map!(vec, skymap::PolarizedMap{T, O}, hitmap::Healpix.Map{T, O}, obs::Observation; comm=nothing, unseen=NaN) where {T <: Number, O <: Healpix.Order}
+    update_binned_map!(skymap::PolarizedMap{T, O}, hitmap::Healpix.Map{T, O}, obs::Observation; comm=nothing, unseen=NaN) where {T <: Number, O <: Healpix.Order}
+    update_binned_map!(skymap::PolarizedMap{T, O}, hitmap::Healpix.Map{T, O}, obs_list::Array{Observation, 1}; comm=nothing, unseen=NaN) where {T <: Number, O <: Healpix.Order}
+
+Apply Eqs. (18), (19), and (20) to compute the values of I, Q, and U
+from a TOD, and save the result in `skymap` and `hitmap`.
+
+The three versions differ for the source of the TOD calibrated data:
+
+- if the `vec` parameter is present (first form), it will be used
+  instead of `obs.tod` (second form)
+- instead of `obs` (a single [`Observation`](@ref) object), you can
+  pass an array `obs_list` (third form). All the elements in this
+  array will be used to update `skymap` and `hitmap`.
+
+"""
+update_binned_map!
+
+################################################################################
+# Destriping results
+
+@doc raw"""
+    mutable struct DestripingData{T <: Number, O <: Healpix.Order}
+
+Structure containing the result of a destriping operation. It contains
+the following fields:
+
+- `skymap`: a `PolarizedMap` containing the maximum-likelihood map
+- `hitmap`: a map containing the weights of each pixel (this is not
+  the hit count, as it is normalized over the value of ``σ^2`` for
+  each sample in the TOD)
+- `nobs_matrix`: an array of [`NobsMatrixelement`](@ref) objects,
+  which can be used to determine which pixels were the most
+  troublesome in the reconstruction of tehe I/Q/U components
+
+The baselines are not saved in this object; rather, they are returned
+by the function [`destripe!`](@ref).
+
+"""
+mutable struct DestripingData{T <: Number, O <: Healpix.Order}
+    skymap::PolarizedMap{T, O}
+    hitmap::Healpix.Map{T, O}
+    nobs_matrix::Array{NobsMatrixElement, 1}
+end
+
+@doc raw"""
+    reset_maps!(d::DestripingData{T, O}) where {T <: Number, O <: Healpix.Order}
+
+Set the skymap and the hitmap in `d` to zero. Nothing is done on the
+field `nobs_matrix`.
+
+"""
+function reset_maps!(d::DestripingData{T, O}) where {T <: Number, O <: Healpix.Order}
+    d.skymap.i .= 0.0
+    d.skymap.q .= 0.0
+    d.skymap.u .= 0.0
+    
+    d.hitmap .= 0.0    
+end
+
+################################################################################
+
+@doc raw"""
+    mutable struct CleanedTOD{T <: Number}
+
+This structure is used to associated a TOD containing some measurement
+with the set of baselines estimated by the destriper. It implements
+the iterator interface, which means that it can be used like if it
+were an array.
+
+"""
+mutable struct CleanedTOD{T <: Number}
+    tod::AbstractArray{T,1}
+    baselines::AbstractArray{T,1}
+end
+
+function Base.iterate(iter::CleanedTOD{T}) where {T <: Number}
+    isempty(iter.tod) && return nothing
+
+    first_tod, tod_iter = iterate(iter.tod)
+    first_baseline, baseline_iter = iterate(iter.baselines)
+    (first_tod - first_baseline, (tod_iter, baseline_iter))
+end
+
+function Base.iterate(iter::CleanedTOD{T}, state) where {T <: Number}
+    next_tod, next_baseline = state
+    next_tod = iterate(iter.tod, next_tod)
+    next_baseline = iterate(iter.baselines, next_baseline)
+    
+    next_tod === nothing && return nothing
+    next_baseline == nothing && return nothing
+
+    (next_tod[1] - next_baseline[1], (next_tod[2], next_baseline[2]))
+end
+
+Base.getindex(c::CleanedTOD{T}, idx) where {T <: Number} = c.tod[idx] - c.baselines[idx]
+Base.length(c::CleanedTOD{T}) where {T <: Number} = length(c.tod)
+
+################################################################################
+
+function compute_z_and_subgroup!(
+    dest_baselines,
+    vec,
+    baseline_lengths,
+    destriping_data::DestripingData{T, O},
+    obs::Observation;
+    comm = nothing,
+    unseen = missing,
+) where {T, O <: Healpix.Order}
+
+    # WARNING: unlike compute_z_and_group!, this does *not* update
+    # `destriping_data`!
+    
+    length(baseline_lengths) > 0 || return
+    @assert sum(baseline_lengths) == length(obs.tod)
+    @assert length(baseline_lengths) == length(dest_baselines)
+
+    iqu = Array{Float64}(undef, 3)
+
+    @inbounds @simd for idx in eachindex(dest_baselines)
+        dest_baselines[idx] = 0.0
+    end
+    
+    baseline_idx = 1
+    samples_in_baseline = 0
+    for (idx, sigmasamp, mapsamp) in zip(eachindex(obs.pixidx),
+                                         obs.sigma_squared,
+                                         obs.pixidx)
+        iqu[1] = destriping_data.skymap.i[mapsamp]
+        iqu[2] = destriping_data.skymap.q[mapsamp]
+        iqu[3] = destriping_data.skymap.u[mapsamp]
+        
+        iqu .= destriping_data.nobs_matrix[mapsamp].invm * iqu
+        sin_term, cos_term = sincos(2 * obs.psi_angle[idx])
+        signal = (iqu[1] + iqu[2] * cos_term + iqu[3] * sin_term)
+        dest_baselines[baseline_idx] += (vec[idx] - signal) / sigmasamp
+        
+        samples_in_baseline += 1
+        if samples_in_baseline == baseline_lengths[baseline_idx]
+            baseline_idx += 1
+            samples_in_baseline = 0
+        end
+    end
+end
+
+function compute_z_and_subgroup!(
+    dest_baselines,
+    baseline_lengths,
+    destriping_data::DestripingData{T, O},
+    obs::Observation;
+    comm = nothing,
+    unseen = missing,
+) where {T, O <: Healpix.Order}
+
+    # WARNING: unlike compute_z_and_group!, this does *not* update
+    # `destriping_data`!
+    
+    compute_z_and_group!(
+        dest_baselines,
+        obs.tod,
+        baseline_lengths,
+        destriping_data,
+        obs,
+        comm = comm,
+        unseen = unseen,
+    )
+end
+
+@doc raw"""
+    compute_z_and_subgroup!(dest_baselines, vec, baseline_lengths, destriping_data::DestripingData{T, O}, obs::Observation; comm=nothing, unseen=NaN) where {T, O <: Healpix.Order}
+    compute_z_and_subgroup!(dest_baselines, baseline_lengths, destriping_data::DestripingData{T, O}, obs::Observation; comm=nothing, unseen=NaN) where {T, O <: Healpix.Order}
+
+Compute the application of matrix A in Eq. (25) in
+KurkiSuonio2009. The result is a set of baselines, and it is saved in
+`dest_baselines` (an array of elements whose type is `T`). The two
+forms differ only in the presence of the `vec` parameter: if it is not
+present, the value of `obs.tod` will be used.
+
+This function only operates on single observations. If you want to
+apply it to an array of observations, use
+[`compute_z_and_group!`](@ref).
+
+"""
+compute_z_and_subgroup!
+
+function compute_z_and_group!(
+    dest_baselines,
+    vectors,
+    baseline_lengths,
+    destriping_data::DestripingData{T, O},
+    obs_list::Array{Observation, 1};
+    comm = nothing,
+    unseen = missing,
+) where {T, O <: Healpix.Order}
+    
+    @assert length(obs_list) == length(vectors)
+    @assert length(obs_list) == length(baseline_lengths)
+    @assert length(obs_list) == length(dest_baselines)
+
+    for (idx, cur_obs) in enumerate(obs_list)
+        update_binned_map!(
+            vectors[idx],
+            destriping_data.skymap,
+            destriping_data.hitmap,
+            cur_obs,
+            comm = comm,
+            unseen = unseen,
+        )
+    end
+    
+    for (idx, cur_obs, cur_baseline_length) in zip(1:length(obs_list), obs_list, baseline_lengths)
+        @assert length(cur_baseline_length) == length(dest_baselines[idx])
+        
+        compute_z_and_subgroup!(
+            dest_baselines[idx],
+            vectors[idx],
+            cur_baseline_length,
+            destriping_data,
+            cur_obs,
+            comm = comm,
+            unseen = unseen,
+        )
+    end
+end
+
+function compute_z_and_group!(
+    dest_baselines,
+    baseline_lengths,
+    destriping_data::DestripingData{T, O},
+    obs_list::Array{Observation, 1};
+    comm = nothing,
+    unseen = missing,
+) where {T, O <: Healpix.Order}
+
+    @assert length(obs_list) == length(baseline_lengths)
+    @assert length(obs_list) == length(dest_baselines)
+    
+    for cur_obs in obs_list
+        update_binned_map!(
+            cur_obs.tod,
+            destriping_data.skymap,
+            destriping_data.hitmap,
+            cur_obs,
+            comm = comm,
+            unseen = unseen,
+        )
+    end
+
+    for (idx, cur_obs, cur_baseline_length) in zip(1:length(obs_list), obs_list, baseline_lengths)
+        @assert length(cur_baseline_length) == length(dest_baselines[idx])
+        
+        compute_z_and_subgroup!(
+            dest_baselines[idx],
+            cur_obs.tod,
+            cur_baseline_length,
+            destriping_data,
+            cur_obs,
+            comm = comm,
+            unseen = unseen,
+        )
+    end
+end
+
+
+@doc raw"""
+    compute_z_and_group!(dest_baselines, vectors, baseline_lengths, destriping_data::DestripingData{T, O}, obs_list::Array{Observation, 1}; comm=nothing, unseen=NaN) where {T, O <: Healpix.Order}
+    compute_z_and_group!(dest_baselines, baseline_lengths, destriping_data::DestripingData{T, O}, obs_list::Array{Observation, 1}; comm=nothing, unseen=NaN) where {T, O <: Healpix.Order}
+
+Compute the application of matrix A in Eq. (25) in
+KurkiSuonio2009. The result is a set of baselines, and it is saved in
+`dest_baselines` (an array of elements whose type is `T`). The two
+forms differ only in the presence of the `vec` parameter: if it is not
+present, the value of `obs.tod` will be used.
+
+"""
+compute_z_and_group!
+
+################################################################################
+
+function compute_residuals!(
+    residuals,
+    baselines,
+    baseline_lengths,
+    destriping_data::DestripingData{T, O},
+    obs_list::Array{Observation, 1};
+    comm = nothing,
+    unseen = missing,
+) where {T, O <: Healpix.Order}
+
+    @assert length(residuals) == length(obs_list)
+    @assert length(residuals) == length(baseline_lengths)
+    
+    reset_maps!(destriping_data)
+    
+    compute_z_and_group!(
+        residuals,
+        baseline_lengths,
+        destriping_data,
+        obs_list,
+    )
+
+    left_side = [Array{T}(undef, length(residuals[idx])) for idx in 1:length(residuals)]
+    
+    reset_maps!(destriping_data)
+    
+    compute_z_and_group!(
+        left_side, 
+        baselines,
+        baseline_lengths,
+        destriping_data,
+        obs_list,
+    )
+end
+
+################################################################################
+
+function array_dot(
+    x::Array{RunLengthArray{N, T}},
+    y;
+    comm = nothing,
+) where {N <: Integer, T <: Number}
+    
+    @assert length(x) == length(y)
+
+    result = 0.0
+    for (curx, cury) in zip(x, y)
+        result += dot(values(curx), cury)
+    end
+
+    result
+end
+
+function array_dot(x, y; comm = nothing)
+    @assert length(x) == length(y)
+
+    result = 0.0
+    for (curx, cury) in zip(x, y)
+        result += dot(curx, cury)
+    end
+
+    result
+end
+
+@doc raw"""
+    array_dot(x, y; comm = nothing)
+
+Compute the dot product between `x` and `y`, assuming that both are
+arrays of arrays.
+
+"""
+array_dot
+
+@doc raw"""
+    calc_stopping_factor(r; comm=nothing)
+
+Calculate the stopping factor required by the Conjugated Gradient
+method to determine if the iteration must be stopped or not. The
+parameter `r` is the vector of the residuals.
+
+"""
+calc_stopping_factor(r; comm = nothing) = maximum(abs.(Iterators.flatten(r)))
+
+################################################################################
+
+@doc raw"""
+    apply_offset_to_baselines!(baselines)
+
+Add a constant offset to all the baselines such that their sum is zero.
+
+"""
+function apply_offset_to_baselines!(
+    baselines::Array{RunLengthArray{Int, T}, 1},
+) where {T <: Number}
+
+    baseline_sum = 0.0
+    baseline_num = 0
+    for cur_baseline in baselines
+        baseline_sum += sum(values(cur_baseline))
+        baseline_num += length(values(cur_baseline))
+    end
+    baseline_sum /= baseline_num
+
+    for cur_baseline in baselines
+        cur_baseline.values .-= baseline_sum
+    end
+end
+
+@doc raw"""
+    calculate_cleaned_map!(obs_list, baselines, destriping_data; comm=nothing, unseen=missing)
+
+Provided a set of baselines in `baselines`, this function cleans the
+TOD in `obs_list` and computes the I/Q/U maps, which are saved in
+`destriping_data`.
+
+"""
+function calculate_cleaned_map!(
+    obs_list::Array{Observation, 1},
+    baselines::Array{RunLengthArray{Int, T}, 1},
+    destriping_data::DestripingData{T, O};
+    comm = nothing,
+    unseen = missing,
+) where {T <: Number, O <: Healpix.Order}
+    
+    cleaned_tod = CleanedTOD{Float64}([], [])
+    reset_maps!(destriping_data)
+    
+    for (cur_obs, cur_baseline) in zip(obs_list, baselines)
+        cleaned_tod.tod = cur_obs.tod
+        cleaned_tod.baselines = cur_baseline
+
+        update_binned_map!(
+            cleaned_tod,
+            destriping_data.skymap,
+            destriping_data.hitmap,
+            cur_obs,
+            comm = comm,
+            unseen = unseen,
+        )
+    end
+
+    # Now solve for the I, Q, U parameters
+    iqu = Array{Float64}(undef, 3)
+    for curpix in eachindex(destriping_data.nobs_matrix)
+        iqu[1] = destriping_data.skymap.i[curpix]
+        iqu[2] = destriping_data.skymap.q[curpix]
+        iqu[3] = destriping_data.skymap.u[curpix]
+
+        iqu .= destriping_data.nobs_matrix[curpix].invm * iqu
+
+        destriping_data.skymap.i[curpix] = iqu[1]
+        destriping_data.skymap.q[curpix] = iqu[2]
+        destriping_data.skymap.u[curpix] = iqu[3]
+    end
+end
+
+include("preconditioners.jl")
+
+include("covmatrix.jl")
+
+@doc raw"""
+    destripe!(obs_list, baselines, destriping_data; threshold, max_iterations, comm, unseen, callback, use_preconditioner) where {T <: Number, O <: Healpix.Order}
+
+Apply the destriping algorithm to the TOD in `obs_list`. The result is
+returned in `baselines` (set of baselines) and `destriping_data`
+(I/Q/U maps, weight map, M_p matrices).
+
+The parameters must satisfy the following constraints:
+
+- `obs_list` must be an array of `N` [`Observation`](@ref) objects;
+- `baselines` must be an array of `N` `RunLengthArray` objects; each
+  of them must have all the values set to zero; the length of each run
+  specifies the length of the baseline in terms of the samples in the
+  TOD in `obs_list`
+- `destriping_data` must be a [`DestripingData`](@ref) object. It does
+  not need to have been initialized using [`reset_maps!`](@ref).
+
+The optional keyword have the following meaning and default value:
+
+- `max_iterations` is the maximum number of allowed iterations for the
+  Conjugated Gradient algorithm. The default is 1000.
+- `comm` is a MPI communicator object, or `nothing` is MPI is not
+  used.
+- `unseen` is the value to be used for pixels in the map that have not
+  been observed. The default is `missing`; other sensible values are
+  `nothing` and `NaN`.
+- `callback` is either `nothing` (the default) or a function that is
+  called before the CG algorithm starts, and then once every
+  iteration. It can be used to monitor the progress of the destriper,
+  or to save intermediate results in a database or a file. The
+  function must accept the following parameters:
+
+  1. Iteration number, starting from 1
+  2. Maximum number of iterations, equal to `max_iterations`
+  3. Current stopping factor
+  4. The value of `destriping_data`
+
+The function uses Julia's `Logging` module. Therefore, you can enable
+the output of diagnostic messages, like in the following example:
+
+```julia
+global_logger(ConsoleLogger(stderr, Debug))
+
+# This command is going to produce a lot of output…
+destripe!(...)
+```
+
+"""
+function destripe!(
+    obs_list::Array{Observation, 1},
+    baselines::Array{RunLengthArray{Int, T}, 1},
+    destriping_data::DestripingData{T, O};
+    threshold = 1e-9,
+    max_iterations = 1000,
+    comm = nothing,
+    unseen = missing,
+    callback = nothing,
+    use_preconditioner = true,
+) where {T <: Number, O <: Healpix.Order}
+
+    @assert length(obs_list) == length(baselines)
+
+    # This variable is not going to change during the execution of the function
+    baseline_lengths = [runs(baselines[idx]) for idx in 1:length(obs_list)]
+
+    r = [Array{T}(undef, length(values(baselines[idx]))) for idx in 1:length(obs_list)]
+    rnext = deepcopy(r)
+
+    compute_nobs_matrix!(destriping_data.nobs_matrix, obs_list)
+    
+    compute_residuals!(
+        r,
+        baselines,
+        baseline_lengths,
+        destriping_data,
+        obs_list,
+        comm = comm,
+        unseen = unseen,
+    )
+    k = 0
+
+    list_of_stopping_factors = []
+    
+    stopping_factor = calc_stopping_factor(r, comm = comm)
+    push!(list_of_stopping_factors, stopping_factor)
+    stopping_factor < threshold && return list_of_stopping_factors
+
+    precond = if use_preconditioner
+        jacobi_preconditioner(
+            [runs(b) for b in baselines],
+            T
+        )
+    else
+        IdentityPreconditioner()
+    end
+    
+    z = deepcopy(r)
+    apply!(precond, z)
+
+    old_z_dot_r = array_dot(z, r, comm = comm)
+    p = [RunLengthArray{Int, T}(runs(baselines[idx]), z[idx]) for idx in 1:length(baselines)]
+    best_stopping_factor = stopping_factor
+    best_a = deepcopy(baselines)
+
+    ap = [Array{T}(undef, length(r[idx])) for idx in 1:length(r)]
+    while true
+        k += 1
+        @debug "CG iteration $k/$max_iterations, stopping factor = $stopping_factor"
+        
+        if k >= max_iterations
+            @warn "The destriper did not converge after $k iterations"
+            baselines = best_a
+            break
+        end
+
+        reset_maps!(destriping_data)
+        compute_z_and_group!(
+            ap,
+            p,
+            baseline_lengths,
+            destriping_data,
+            obs_list,
+            comm = comm,
+            unseen = unseen,
+        )
+        γ = old_z_dot_r / array_dot(p, ap, comm = comm)
+        for obsidx in 1:length(obs_list)
+            baselines[obsidx].values .+= γ * p[obsidx].values
+            rnext[obsidx] .= r[obsidx] - γ * ap[obsidx]
+        end
+        # Remove the mean value from the baselines
+        apply_offset_to_baselines!(baselines)
+
+        stopping_factor = calc_stopping_factor(r, comm = comm)
+        push!(list_of_stopping_factors, stopping_factor)
+        if stopping_factor < best_stopping_factor
+            best_a = deepcopy(baselines)
+            best_stopping_factor = stopping_factor
+        end
+        if stopping_factor < threshold
+            @info "Destriper converged after $k iterations, stopping factor ($(stopping_factor)) < threshold ($(threshold))"
+            break
+        end
+
+        z = deepcopy(rnext)
+        apply!(precond, z)
+        new_z_dot_r = array_dot(z, rnext, comm = comm)
+
+        for obsidx in 1:length(obs_list)
+            r[obsidx] .= rnext[obsidx]
+            p[obsidx].values .= z[obsidx] + (new_z_dot_r / old_z_dot_r) * p[obsidx].values
+        end
+
+        (callback === nothing) || callback(k, max_iterations, stopping_factor, destriping_data)
+        old_z_dot_r = new_z_dot_r
+    end
+
+    @debug "Producing the map"
+    calculate_cleaned_map!(obs_list, baselines, destriping_data, comm = comm, unseen = unseen)
+
+    list_of_stopping_factors
+end

--- a/src/preconditioners.jl
+++ b/src/preconditioners.jl
@@ -1,0 +1,31 @@
+abstract type Preconditioner end
+
+struct IdentityPreconditioner <: Preconditioner
+end
+
+struct JacobiPreconditioner{T <: Number} <: Preconditioner
+    diagonal_list::Array{Array{T, 1}, 1}
+end
+
+function apply!(precond::IdentityPreconditioner, baselines) where {T <: Number}
+    # Do nothing
+end
+
+function apply!(precond::JacobiPreconditioner{T}, baselines) where {T <: Number}
+    @assert length(baselines) == length(precond.diagonal_list)
+    
+    for idx in eachindex(baselines)
+        baselines[idx] .*= precond.diagonal_list[idx]
+    end
+end
+
+function jacobi_preconditioner(baseline_length_list, T)
+    # TODO: once we specify a mask or flags, we need to take them into account here!
+    diagonals = [Array{T}(undef, length(x)) for x in baseline_length_list]
+
+    for cur_diag_idx in eachindex(diagonals)
+        diagonals[cur_diag_idx] .= 1 ./ baseline_length_list[cur_diag_idx]
+    end
+    
+    JacobiPreconditioner{T}(diagonals)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,10 +6,6 @@ using Test
     include("test_quaternions.jl")
 end
 
-@testset "Run-length arrays" begin
-    include("test_rlarrays.jl")
-end
-
 @testset "Pointing generation" begin
     include("test_genpointings.jl")
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,6 +6,10 @@ using Test
     include("test_quaternions.jl")
 end
 
+@testset "Run-length arrays" begin
+    include("test_rlarrays.jl")
+end
+
 @testset "Pointing generation" begin
     include("test_genpointings.jl")
 end
@@ -16,4 +20,8 @@ end
 
 @testset "Beam functions" begin
     include("test_beams.jl")
+end
+
+@testset "Map-making functions" begin
+    include("test_mapmaking.jl")
 end

--- a/test/test_mapmaking.jl
+++ b/test/test_mapmaking.jl
@@ -1,0 +1,189 @@
+import LinearAlgebra: I, Symmetric, cond, diagm, dot
+using RunLengthArrays
+import Healpix
+
+################################################################################
+# Pointing generation (used for testing)
+
+function build_F(ntod, baseline_lengths)
+    F = zeros(ntod, length(baseline_lengths))
+
+    startidx = 1
+    for (i, cur_len) in enumerate(baseline_lengths)
+        nelems = min(ntod - startidx + 1, cur_len)
+        F[startidx:(startidx + nelems - 1), i] .= 1
+        startidx += nelems
+    end
+    
+    F
+end
+
+function build_P_and_psi(pixidx, npix)
+    ntod = length(pixidx)
+    P = zeros(ntod, 3npix)
+    psi = Array{Float64}(undef, ntod)
+
+    curangle = 0.0
+    for (idx, curpix) in enumerate(pixidx)
+        psi[idx] = curangle
+
+        P[idx, 1 + 3(curpix - 1)] = 1
+        P[idx, 2 + 3(curpix - 1)] = cos(2curangle)
+        P[idx, 3 + 3(curpix - 1)] = sin(2curangle)
+
+        curangle += 2π / ntod
+    end
+
+    P, psi
+end
+
+generate_pixidx(ntod, npix) = Iterators.take(Iterators.cycle(1:npix), ntod) |> collect
+
+################################################################################
+
+NTOD = 512
+BASELINES = RunLengthArray{Int, Float64}(
+    Int[NTOD/8, NTOD/4, NTOD/4, 3NTOD/8],
+    Float64[2, -3, 1, 0],
+)
+
+# Map with NSIDE = 1
+skymap = CMBSim.PolarizedMap{Float64, Healpix.RingOrder}(
+    Float64[1,   3,   -4,    6,    5,   -1,   -4,    2,   8,   0,   -1,   -2],
+    Float64[1.0, 1.8,  0.7,  6.8, -2.2,  6.0,  0.3, -0.3, 4.7, 7.2,  5.1,  7.2],
+    Float64[1.2, 0.4,  0.7, -1.4,  5.4,  4.9,  4.1, -1.0, 4.2, 5.9,  2.4,  3.8],
+)
+
+# The order is I1, Q1, U1, I2, Q2, U2…
+m = reshape([skymap.i skymap.q skymap.u]', 3length(skymap.i))
+
+NPIX = length(skymap.i)
+PIXIDX = generate_pixidx(NTOD, NPIX)
+
+diagCw = [1.1 for _ in 1:NTOD]
+Cw = diagm(0 => diagCw)
+invCw = inv(Cw)
+
+P, PSI = build_P_and_psi(PIXIDX, NPIX)
+F = build_F(NTOD, runs(BASELINES))
+M = P' * invCw * P
+invM = inv(M)
+Z = I - P * invM * P' * invCw
+D = F' * invCw * Z * F
+
+y = P * m + F * values(BASELINES)
+
+# These are the terms in the destriping equation "Ax = b"
+A = F' * invCw * Z * F
+b = F' * invCw * Z * y
+
+baseline_guess = inv(F' * invCw * Z * F) * F' * invCw * Z * y
+# Remove the average
+baseline_guess .-= sum(baseline_guess) / length(baseline_guess)
+# This is the maximum-likelihood map
+map_guess = inv(P' * invCw * P) * P' * invCw * (y - F * baseline_guess)
+
+################################################################################
+# True map-maker
+
+time_samp = 0.01 # Integration time for one sample; it is not really used
+
+# This holds the same information as matrix M = P' ⋅ Cw^-1 ⋅ P
+nobs_matrix = [CMBSim.NobsMatrixElement() for i in 1:NPIX]
+
+obs_range1 = 1:sum(runs(BASELINES)[1:2])
+obs_range2 = (sum(runs(BASELINES)[1:2]) + 1):NTOD
+
+obs_list = CMBSim.Observation[
+    CMBSim.observation(
+        pixidx = PIXIDX[obs_range1],
+        psi_angle = PSI[obs_range1],
+        tod = y[obs_range1],
+        sigma_squared = diagCw[obs_range1],
+        name = "Det1",
+    )
+    CMBSim.observation(
+        pixidx = PIXIDX[obs_range2],
+        psi_angle = PSI[obs_range2],
+        tod = y[obs_range2],
+        sigma_squared = diagCw[obs_range2],
+        name = "Det2",
+    )
+]
+
+CMBSim.compute_nobs_matrix!(nobs_matrix, obs_list)
+
+# Verify that nobs_matrix is really a representation of matrix M
+for i in 1:NPIX
+    startidx = 1 + 3(i - 1)
+    subm = @view M[startidx:(startidx + 2), startidx:(startidx + 2)]
+    @test nobs_matrix[i].invm ≈ inv(subm)
+    @test Symmetric(nobs_matrix[i].m) * nobs_matrix[i].invm ≈ I
+end
+
+# Test compute_z_and_group!
+
+@test length(obs_list) == 2
+@test length(runs(BASELINES)) == 4
+dest_baselines = [
+    Float64[0.0, 0.0],
+    Float64[0.0, 0.0],
+]
+
+destriping_data = CMBSim.DestripingData(
+    CMBSim.PolarizedMap{Float64, Healpix.RingOrder}(
+        zeros(12),
+        zeros(12),
+        zeros(12),
+    ),
+    Healpix.Map{Float64, Healpix.RingOrder}(1),
+    nobs_matrix,
+)
+
+CMBSim.compute_z_and_group!(
+    dest_baselines,
+    [runs(BASELINES)[1:2], runs(BASELINES)[3:4]],
+    destriping_data,
+    obs_list,
+)
+
+@test collect(Iterators.flatten(dest_baselines)) ≈ b
+
+left_side = [
+    Float64[0.0, 0.0],
+    Float64[0.0, 0.0],
+]
+
+CMBSim.reset_maps!(destriping_data)
+
+CMBSim.compute_z_and_group!(
+    left_side, 
+    [collect(BASELINES)[obs_range1], collect(BASELINES)[obs_range2]],
+    [runs(BASELINES)[1:2], runs(BASELINES)[3:4]],
+    destriping_data,
+    obs_list,
+)
+
+@test collect(Iterators.flatten(left_side)) ≈ A * values(BASELINES)
+
+CMBSim.reset_maps!(destriping_data)
+start_baselines = [
+    RunLengthArray{Int,Float64}(runs(BASELINES)[1:2], [0.0, 0.0]),
+    RunLengthArray{Int,Float64}(runs(BASELINES)[3:4], [0.0, 0.0]),
+]
+
+CMBSim.destripe!(
+    obs_list,
+    start_baselines,
+    destriping_data,
+    max_iterations = 15,
+    threshold = 1e-14,
+    use_preconditioner = true,
+)
+
+estimated_baselines = collect(Iterators.flatten([x.values for x in start_baselines]))
+@test estimated_baselines ≈ collect(BASELINES.values)
+
+@test (abs.(destriping_data.skymap.i .- skymap.i) |> maximum) < 0.3
+@test (abs.(destriping_data.skymap.q .- skymap.q) |> maximum) < 0.3
+@test (abs.(destriping_data.skymap.u .- skymap.u) |> maximum) < 0.3


### PR DESCRIPTION
This PR includes the function `destripe!`, which implements a destriping algorithm to produce maps out of TODs contaminated by 1/f-noise.